### PR TITLE
Fixed #3

### DIFF
--- a/java-keyring-example/pom.xml
+++ b/java-keyring-example/pom.xml
@@ -123,7 +123,7 @@
                     <charset>UTF-8</charset>
                     <show>public</show>
                 </configuration>
-                <version>2.7</version>
+                <version>3.2.0</version>
             </plugin>
         </plugins>
     </build>

--- a/java-keyring/pom.xml
+++ b/java-keyring/pom.xml
@@ -122,7 +122,7 @@
                     <charset>UTF-8</charset>
                     <show>public</show>
                 </configuration>
-                <version>2.7</version>
+                <version>3.2.0</version>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,11 @@
     <url>https://bitbucket.org/east301/java-keyring/</url>
     <packaging>pom</packaging>
 
+    <properties>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+    </properties>
+
     <licenses>
         <license>
             <name>The BSD 3-Clause License</name>
@@ -106,12 +111,12 @@
             <dependency>
                 <groupId>net.java.dev.jna</groupId>
                 <artifactId>jna</artifactId>
-                <version>4.1.0</version>
+                <version>5.8.0</version>
             </dependency>
             <dependency>
                 <groupId>net.java.dev.jna</groupId>
                 <artifactId>jna-platform</artifactId>
-                <version>4.1.0</version>
+                <version>5.8.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Fix for MacOS BigSur.

Updated also Java to at least v8 and maven-java-doc plugin to make it work on modern environments. Testet with JDK8 + JDK13.